### PR TITLE
feat: add unregister functionality

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @web3inbox/core
 
+## 0.0.23
+
+### Patch Changes
+
+- Add unregister functionality
+
 ## 0.0.22
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@walletconnect/core": "^2.10.2",
-    "@walletconnect/notify-client": "^0.14.2",
+    "@walletconnect/notify-client": "^0.14.4",
     "valtio": "^1.11.2"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/core",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -124,9 +124,9 @@ export class Web3InboxClient {
   /**
    * Retrieve set account.
    *
-   * @returns {string} Set account
+   * @returns {string|undefined} Set account
    */
-  public getAccount() {
+  public getAccount(): string | undefined {
     return Web3InboxClient.clientState.account;
   }
 
@@ -450,8 +450,27 @@ export class Web3InboxClient {
       Web3InboxClient.clientState.account = params.account;
 
       return registeredIdentity;
-    } catch (e) {
-      throw new Error("Failed to register");
+    } catch (e: any) {
+      throw new Error(`Failed to register: ${e.message}`);
+    }
+  }
+
+  /**
+   * Unregister account on keyserver and unsubscribe from all topics
+   *
+   * @param {Object} params - register params
+   * @param {string} params.account - Account to unregister.
+   *
+   */
+  public async unregister(params: {
+    account: string;
+  }): Promise<void> {
+    try {
+      await this.notifyClient.unregister(params);
+
+      Web3InboxClient.clientState.registration = undefined
+    } catch (e: any) {
+      throw new Error(`Failed to uregister: ${e.message}`);
     }
   }
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @web3inbox/widget-react
 
+## 0.6.26
+
+### Patch Changes
+
+- Add unregister functionality
+- Updated dependencies
+  - @web3inbox/core@0.0.23
+
 ## 0.6.25
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3inbox/widget-react",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/react/src/hooks/web3inboxClient.ts
+++ b/packages/react/src/hooks/web3inboxClient.ts
@@ -76,6 +76,7 @@ export const useW3iAccount = () => {
   const [isRegistered, setIsRegistered] = useState<boolean>(false);
   const [isRegistering, setIsRegistering] = useState<boolean>(false);
 
+
   const { account, registration } = useClientState();
 
   const setAccount = useCallback(
@@ -111,10 +112,17 @@ export const useW3iAccount = () => {
     [client, account]
   );
 
+  const unregister = useCallback(async () => {
+    if(client && account) {
+      return client.unregister({account})
+    }
+  }, [client, account])
+
   return {
     account,
     setAccount,
     register,
+    unregister,
     isRegistering,
     isRegistered,
     identityKey:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1793,10 +1793,10 @@
     "@walletconnect/modal-core" "2.6.1"
     "@walletconnect/modal-ui" "2.6.1"
 
-"@walletconnect/notify-client@^0.14.2":
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/@walletconnect/notify-client/-/notify-client-0.14.2.tgz#6eb220f3e36b6a252927bbdee21bb4272a0ad796"
-  integrity sha512-q9txdUoQn61KBw4SzgrZ81MH0v3oUC++Kp1TuEnMTSJSF7UZfZhIXIA3KhoGMUzxXutiAAUAJjcHmUhXdabwRA==
+"@walletconnect/notify-client@^0.14.4":
+  version "0.14.4"
+  resolved "https://registry.yarnpkg.com/@walletconnect/notify-client/-/notify-client-0.14.4.tgz#ba50f42a5cb112e7cc6cc7d27e4653e357a0abb4"
+  integrity sha512-nGPxsys0VYAHx71G6WdvbRLisP2ArXaRkN0e2iEj+CxIYV31UfPeTOEP4oQqyKx5sR/mbDS5NyDHNewZd5KqJQ==
   dependencies:
     "@noble/ed25519" "^1.7.3"
     "@walletconnect/cacao" "1.0.2"


### PR DESCRIPTION
- bump notify client to 0.14.4
- expose `unregister` function from `notify-client` in hooks and core