### PR TITLE
fix: isRegistering not updating on fail

### DIFF
--- a/packages/react/src/WidgetController.tsx
+++ b/packages/react/src/WidgetController.tsx
@@ -139,9 +139,7 @@ export const W3iWidget: React.FC<W3iWidgetProps> = ({
   const ref = useRef<HTMLDivElement>(null);
   useColorModeValue(ref);
 
-  const { setAccount, register, isRegistering } = useW3iAccount();
-
-  console.log({isRegistering})
+  const { setAccount, register } = useW3iAccount();
 
   useEffect(() => {
     if (ready && account) {

--- a/packages/react/src/WidgetController.tsx
+++ b/packages/react/src/WidgetController.tsx
@@ -139,7 +139,9 @@ export const W3iWidget: React.FC<W3iWidgetProps> = ({
   const ref = useRef<HTMLDivElement>(null);
   useColorModeValue(ref);
 
-  const { setAccount, register } = useW3iAccount();
+  const { setAccount, register, isRegistering } = useW3iAccount();
+
+  console.log({isRegistering})
 
   useEffect(() => {
     if (ready && account) {
@@ -154,6 +156,7 @@ export const W3iWidget: React.FC<W3iWidgetProps> = ({
   }, [account, register, onSign, ready]);
 
   const { isOpen } = useManageView();
+
 
   useEffect(() => {
     console.warn(

--- a/packages/react/src/WidgetController.tsx
+++ b/packages/react/src/WidgetController.tsx
@@ -155,7 +155,6 @@ export const W3iWidget: React.FC<W3iWidgetProps> = ({
 
   const { isOpen } = useManageView();
 
-
   useEffect(() => {
     console.warn(
       "The use of this widget is not recommended as it is in extremely early stages of development"

--- a/packages/react/src/hooks/web3inboxClient.ts
+++ b/packages/react/src/hooks/web3inboxClient.ts
@@ -99,14 +99,14 @@ export const useW3iAccount = () => {
     async (onSign: (m: string) => Promise<string>) => {
       if (client && account) {
         setIsRegistering(true);
-        let identity: string;
+        let identity: string | null;
         try {
           identity = await client.register({
             account,
             onSign,
           });
         } catch (e) {
-          identity = "";
+          identity = null
           console.error(e);
         } finally {
           setIsRegistering(false);

--- a/packages/react/src/hooks/web3inboxClient.ts
+++ b/packages/react/src/hooks/web3inboxClient.ts
@@ -99,11 +99,19 @@ export const useW3iAccount = () => {
     async (onSign: (m: string) => Promise<string>) => {
       if (client && account) {
         setIsRegistering(true);
-        const identity = await client.register({
-          account,
-          onSign,
-        });
-        setIsRegistering(false);
+        let identity: string;
+        try {
+          identity = await client.register({
+            account,
+            onSign,
+          });
+        } catch (e) {
+          identity = "";
+          console.error(e);
+        } finally {
+          setIsRegistering(false);
+        }
+
         return identity;
       }
 


### PR DESCRIPTION
- set `isRegistering` to false if `register` errored out

tested via logging `isRegistering` in `WidgetController` 

(more robust UTs are WIP for hooks)