### PR TITLE
refactor: update useW3iAccount hook life cycle and setAccount logics

### DIFF
--- a/apps/web/components/Subscription.tsx
+++ b/apps/web/components/Subscription.tsx
@@ -38,7 +38,11 @@ function Subscription() {
           >
             {hooksReturn.isLoading
               ? "Loading.."
-              : JSON.stringify(hooksReturn.error ?? hooksReturn.data?.subscription, undefined, 2)}
+              : JSON.stringify(
+                  hooksReturn.error ?? hooksReturn.data?.subscription,
+                  undefined,
+                  2
+                )}
           </pre>
         </Code>
       </AccordionPanel>

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -39,7 +39,6 @@ const Home: NextPage = () => {
     useWeb3InboxClient();
   const {
     data: w3iAccountData,
-    isLoading,
     register,
     setAccount,
     prepareRegistration,
@@ -156,7 +155,7 @@ const Home: NextPage = () => {
       </Heading>
 
       <Flex flexDirection="column" gap={4}>
-        {isLoading || w3iClientIsLoading || !w3iClient ? (
+        {w3iClientIsLoading ? (
           <Button
             leftIcon={<FaBell />}
             colorScheme="cyan"

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { NextPage } from "next";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Accordion,
   Button,
@@ -135,6 +135,11 @@ const Home: NextPage = () => {
       setAccount("");
     },
   });
+
+  useEffect(() => {
+    if (!address || !w3iClientData?.client) return;
+    setAccount(`eip155:1:${address}`);
+  }, [w3iClientData?.client, address]);
 
   return (
     <Flex w="full" flexDirection={"column"} maxW="700px">

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -35,7 +35,7 @@ import { sendNotification } from "../utils/fetchNotify";
 
 const Home: NextPage = () => {
   const { address } = useAccount();
-  const { data: w3iClientData, isLoading: w3iClientIsLoading } =
+  const { data: w3iClient, isLoading: w3iClientIsLoading } =
     useWeb3InboxClient();
   const {
     data: w3iAccountData,
@@ -48,8 +48,6 @@ const Home: NextPage = () => {
     subscribe,
     unsubscribe,
   } = useManageSubscription();
-
-  const w3iClient = w3iClientData?.client;
 
   const { signMessageAsync } = useSignMessage();
   const wagmiPublicClient = usePublicClient();
@@ -136,9 +134,9 @@ const Home: NextPage = () => {
   });
 
   useEffect(() => {
-    if (!address || !w3iClientData?.client) return;
+    if (!address || !w3iClient) return;
     setAccount(`eip155:1:${address}`);
-  }, [w3iClientData?.client, address]);
+  }, [w3iClient, address]);
 
   return (
     <Flex w="full" flexDirection={"column"} maxW="700px">

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -97,6 +97,8 @@ export class Web3InboxClient {
    * @param cb - Callback that gets called when isReady updates
    */
   public static watchIsReady(cb: (isReady: boolean) => void) {
+    cb(Web3InboxClient.clientState.isReady);
+
     return subscribe(Web3InboxClient.clientState, () => {
       cb(Web3InboxClient.clientState.isReady);
     });
@@ -140,11 +142,11 @@ export class Web3InboxClient {
    *
    * @param cb - Callback that gets called when account updates
    */
-  public watchAccount(cb: (acc: string) => void) {
-    const acc = Web3InboxClient.clientState.account;
-    if (!acc) return;
+  public watchAccount(cb: (acc: string | undefined) => void) {
+    cb(Web3InboxClient.clientState.account);
+
     return subscribe(Web3InboxClient.clientState, () => {
-      return cb(acc);
+      return cb(Web3InboxClient.clientState.account);
     });
   }
 
@@ -177,8 +179,10 @@ export class Web3InboxClient {
     account: string,
     cb: (isRegistered: boolean) => void
   ) {
+    this.getAccountIsRegistered(account).then(cb);
+
     return subscribe(Web3InboxClient.clientState, async () => {
-      return cb(await this.getAccountIsRegistered(account));
+      cb(await this.getAccountIsRegistered(account));
     });
   }
 
@@ -238,6 +242,7 @@ export class Web3InboxClient {
     Web3InboxClient.instance.attachEventListeners();
 
     Web3InboxClient.clientState.initting = false;
+
     Web3InboxClient.clientState.isReady = true;
 
     return Web3InboxClient.instance;
@@ -259,7 +264,7 @@ export class Web3InboxClient {
     const domainToSearch = domain ?? this.domain;
 
     console.log(
-      ">>> getSubscription for",
+      ">>>> getSubscription for",
       accountOrInternalAccount,
       domainToSearch
     );
@@ -284,7 +289,7 @@ export class Web3InboxClient {
       accountOrInternalAccount,
       domainToSearch
     );
-    console.log(">>> getSubscription found", subscription);
+    console.log(">>>> getSubscription found", subscription);
 
     return subscription;
   }
@@ -324,6 +329,8 @@ export class Web3InboxClient {
     account?: string,
     domain?: string
   ) {
+    cb(this.getSubscription(account, domain));
+
     return subscribe(Web3InboxClient.subscriptionState, () => {
       cb(this.getSubscription(account, domain));
     });
@@ -339,6 +346,8 @@ export class Web3InboxClient {
     cb: (subscriptions: NotifyClientTypes.NotifySubscription[]) => void,
     account?: string
   ) {
+    cb(this.getSubscriptions(account));
+
     return subscribe(Web3InboxClient.subscriptionState, () => {
       cb(this.getSubscriptions(account));
     });
@@ -674,6 +683,8 @@ export class Web3InboxClient {
     account?: string,
     domain?: string
   ) {
+    cb(this.isSubscribedToDapp(account, domain));
+
     return subscribe(Web3InboxClient.subscriptionState, () => {
       cb(this.isSubscribedToDapp(account, domain));
     });
@@ -692,6 +703,8 @@ export class Web3InboxClient {
     account?: string,
     domain?: string
   ) {
+    cb(this.getSubscription(account, domain)?.scope ?? {});
+
     return subscribe(Web3InboxClient.subscriptionState, () => {
       cb(this.getSubscription(account, domain)?.scope ?? {});
     });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,3 @@
 export { Web3InboxClient } from "./client";
 
-export * as valtio from "valtio"
+export * as valtio from "valtio";

--- a/packages/core/test/client.spec.ts
+++ b/packages/core/test/client.spec.ts
@@ -51,7 +51,6 @@ const testSub3 = {
 };
 
 const resetSingletonState = () => {
-  Web3InboxClient.view = proxy({ isOpen: false });
   Web3InboxClient.subscriptionState = proxy({
     subscriptions: [],
     messages: [],
@@ -89,7 +88,7 @@ const initNonSingletonInstanceW3i = async (
 
   const notifyClient = await NotifyClient.init(notifyParams);
 
-  const w3iClient = new Web3InboxClient(notifyClient, withDomain);
+  const w3iClient = new Web3InboxClient(notifyClient, withDomain, true);
 
   Web3InboxClient.instance = w3iClient;
 
@@ -141,7 +140,7 @@ describe("Web3Inbox Core Client", () => {
       expect(subs).toEqual([]);
     });
 
-    it("correctly updates ready state", async () => {
+    it.skipIf(!projectId)("correctly updates ready state", async () => {
       expect(Web3InboxClient.clientState.isReady).toEqual(false);
 
       // Not awaiting to be able to observe initting state.
@@ -150,7 +149,9 @@ describe("Web3Inbox Core Client", () => {
       expect(Web3InboxClient.clientState.initting).toEqual(true);
 
       await waitForEvent(() => {
-        return !Web3InboxClient.clientState.initting;
+        return (
+          Web3InboxClient.clientState.isReady
+        );
       });
 
       expect(Web3InboxClient.clientState.isReady).toEqual(true);

--- a/packages/react/src/hooks/useAllSubscriptions.ts
+++ b/packages/react/src/hooks/useAllSubscriptions.ts
@@ -4,9 +4,10 @@ import { ErrorOf, HooksReturn, LoadingOf, SuccessOf } from "../types/hooks";
 import { useWeb3InboxClient } from "./useWeb3InboxClient";
 import { useSubscriptionState } from "../utils/snapshots";
 
-type AllSubscriptionsReturn = HooksReturn<{
-  subscriptions: NotifyClientTypes.NotifySubscription[];
-}>;
+type AllSubscriptionsReturn = HooksReturn<
+  NotifyClientTypes.NotifySubscription[]
+>;
+
 /**
  * Hook to get all subscriptions of an account
  *
@@ -15,19 +16,19 @@ type AllSubscriptionsReturn = HooksReturn<{
 export const useAllSubscriptions = (
   account?: string
 ): AllSubscriptionsReturn => {
-  const { data: web3inboxClientData, error } = useWeb3InboxClient();
+  const { data: w3iClient, error } = useWeb3InboxClient();
   const { subscriptions: subscriptionsTrigger } = useSubscriptionState();
   const [subscriptions, setSubscriptions] = useState<
     NotifyClientTypes.NotifySubscription[]
   >([]);
 
   useEffect(() => {
-    if (web3inboxClientData?.client) {
-      setSubscriptions(web3inboxClientData?.client.getSubscriptions(account));
+    if (w3iClient) {
+      setSubscriptions(w3iClient.getSubscriptions(account));
     }
-  }, [subscriptionsTrigger, account, web3inboxClientData]);
+  }, [account, subscriptionsTrigger, w3iClient]);
 
-  if (!web3inboxClientData) {
+  if (!w3iClient) {
     return {
       data: null,
       isLoading: true,
@@ -46,7 +47,7 @@ export const useAllSubscriptions = (
   }
 
   return {
-    data: { subscriptions },
+    data: subscriptions,
     isLoading: false,
     error: null,
   } as SuccessOf<AllSubscriptionsReturn>;

--- a/packages/react/src/hooks/useManageSubscription.ts
+++ b/packages/react/src/hooks/useManageSubscription.ts
@@ -47,7 +47,6 @@ export const useManageSubscription = (
 
     const stopWatching = web3inboxClientData.client.watchSubscription(
       (sub) => {
-        console.log(">>> watcher");
         setSubscription(sub);
       },
       account,
@@ -55,14 +54,6 @@ export const useManageSubscription = (
     );
 
     setWatching(true);
-
-    console.log(
-      ">>> check effect2",
-      web3inboxClientData.client,
-      account,
-      domain
-    );
-
     setSubscription(
       web3inboxClientData.client.getSubscription(account, domain)
     );
@@ -77,7 +68,6 @@ export const useManageSubscription = (
     if (web3inboxClientData) {
       setIsSubscribing(true);
       try {
-        console.log(">>> subscribing to", account, domain);
         await web3inboxClientData.client.subscribeToDapp(account, domain);
       } catch (e) {
         console.error("Failed to subscribe", e);
@@ -86,10 +76,6 @@ export const useManageSubscription = (
         setIsSubscribing(false);
       }
     } else {
-      console.log(
-        ">>> subscribing to",
-        "Trying to subscribe before Web3Inbox Client was initialized"
-      );
       console.error(
         "Trying to subscribe before Web3Inbox Client was initialized"
       );
@@ -115,7 +101,6 @@ export const useManageSubscription = (
   }, [web3inboxClientData, account, domain]);
 
   if (!web3inboxClientData) {
-    console.log(">>> useManageData no client data");
     return {
       data: null,
       isLoading: false,
@@ -126,7 +111,6 @@ export const useManageSubscription = (
   }
 
   if (clientError) {
-    console.log(">>> useManageData client error");
     return {
       data: null,
       isLoading: false,
@@ -142,7 +126,6 @@ export const useManageSubscription = (
   }
 
   if (error) {
-    console.log(">>> useManageData error", error);
     return {
       data: null,
       isLoading: false,

--- a/packages/react/src/hooks/useManageSubscription.ts
+++ b/packages/react/src/hooks/useManageSubscription.ts
@@ -37,15 +37,15 @@ export const useManageSubscription = (
       web3inboxClientData?.client.getSubscription(account, domain) ?? null
     );
 
+  const [watching, setWatching] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
   const [isSubscribing, setIsSubscribing] = useState(false);
   const [isUnsubscribing, setIsUnsubscribing] = useState(false);
 
   useEffect(() => {
-    if (!web3inboxClientData) return;
+    if (!web3inboxClientData?.client || watching) return;
 
-    const stopWatching = web3inboxClientData.client?.watchSubscription(
+    const stopWatching = web3inboxClientData.client.watchSubscription(
       (sub) => {
         console.log(">>> watcher");
         setSubscription(sub);
@@ -54,12 +54,24 @@ export const useManageSubscription = (
       domain
     );
 
+    setWatching(true);
+
+    console.log(
+      ">>> check effect2",
+      web3inboxClientData.client,
+      account,
+      domain
+    );
+
     setSubscription(
       web3inboxClientData.client.getSubscription(account, domain)
     );
 
-    return stopWatching;
-  }, [web3inboxClientData, isClientLoading, account, domain]);
+    return () => {
+      setWatching(false);
+      stopWatching();
+    };
+  }, [account, domain]);
 
   const subscribe = useCallback(async () => {
     if (web3inboxClientData) {

--- a/packages/react/src/hooks/useManageSubscription.ts
+++ b/packages/react/src/hooks/useManageSubscription.ts
@@ -26,7 +26,11 @@ export const useManageSubscription = (
   account?: string,
   domain?: string
 ): ManageSubscriptionReturn => {
-  const { data: w3iClient, error: clientError } = useWeb3InboxClient();
+  const {
+    data: w3iClient,
+    isLoading: clientLoading,
+    error: clientError,
+  } = useWeb3InboxClient();
 
   const [subscription, setSubscription] =
     useState<NotifyClientTypes.NotifySubscription | null>(
@@ -39,6 +43,13 @@ export const useManageSubscription = (
   const [isUnsubscribing, setIsUnsubscribing] = useState(false);
 
   useEffect(() => {
+    if (w3iClient && !clientLoading) {
+      setSubscription(w3iClient.getSubscription(account, domain));
+    }
+  }, [w3iClient, clientLoading]);
+
+  useEffect(() => {
+    console.log({ w3iClient });
     if (!w3iClient || watching) return;
 
     const stopWatching = w3iClient.watchSubscription(
@@ -56,7 +67,7 @@ export const useManageSubscription = (
       setWatching(false);
       stopWatching();
     };
-  }, [account, domain]);
+  }, [account, domain, w3iClient]);
 
   const subscribe = async () => {
     if (!w3iClient) {
@@ -130,13 +141,15 @@ export const useManageSubscription = (
     } as ErrorOf<ManageSubscriptionReturn>;
   }
 
+  const data = {
+    isSubscribing,
+    isUnsubscribing,
+    subscription,
+    isSubscribed: Boolean(subscription),
+  };
+
   return {
-    data: {
-      isSubscribing,
-      isUnsubscribing,
-      subscription,
-      isSubscribed: Boolean(subscription),
-    },
+    data,
     isLoading: false,
     error: null,
     unsubscribe,

--- a/packages/react/src/hooks/useSubscriptionScopes.ts
+++ b/packages/react/src/hooks/useSubscriptionScopes.ts
@@ -6,9 +6,7 @@ import { useSubscriptionState } from "../utils/snapshots";
 
 type SubscriptionScopesReturn = HooksReturn<
   { scopes: NotifyClientTypes.ScopeMap },
-  {
-    updateScopes: (scope: string[]) => Promise<boolean>;
-  },
+  { updateScopes: (scope: string[]) => Promise<boolean> },
   "updateScopes"
 >;
 
@@ -16,27 +14,24 @@ export const useSubscriptionScopes = (
   account?: string,
   domain?: string
 ): SubscriptionScopesReturn => {
-  const { data: web3inboxClientData, error: clientError } =
-    useWeb3InboxClient();
+  const { data: w3iClient, error: clientError } = useWeb3InboxClient();
   const { subscriptions: subscriptionsTrigger } = useSubscriptionState();
   const [subScopes, setSubScopes] = useState<NotifyClientTypes.ScopeMap>(
-    web3inboxClientData?.client.getNotificationTypes(account) ?? {}
+    w3iClient?.getNotificationTypes(account) ?? {}
   );
 
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (web3inboxClientData?.client) {
-      setSubScopes(
-        web3inboxClientData?.client.getNotificationTypes(account, domain)
-      );
+    if (w3iClient) {
+      setSubScopes(w3iClient.getNotificationTypes(account, domain));
     }
-  }, [web3inboxClientData, account, subscriptionsTrigger, domain]);
+  }, [w3iClient, account, subscriptionsTrigger, domain]);
 
   const updateScopes = useCallback(
     (scope: string[]) => {
-      if (web3inboxClientData?.client) {
-        return web3inboxClientData?.client.update(scope, account, domain);
+      if (w3iClient) {
+        return w3iClient.update(scope, account, domain);
       } else {
         setError(
           "Trying to update scope before Web3Inbox Client was initialized "
@@ -44,10 +39,10 @@ export const useSubscriptionScopes = (
         return Promise.resolve(false);
       }
     },
-    [web3inboxClientData, account, domain]
+    [w3iClient, account, domain]
   );
 
-  if (!web3inboxClientData) {
+  if (!w3iClient) {
     return {
       data: null,
       error: null,

--- a/packages/react/src/hooks/useW3IAccount.ts
+++ b/packages/react/src/hooks/useW3IAccount.ts
@@ -74,11 +74,6 @@ export const useW3iAccount = (address?: string): W3iAccountReturn => {
   }, [clientData, account]);
 
   useEffect(() => {
-    if (!address || !clientData?.client) return;
-    setAccount(`eip155:1:${address}`);
-  }, [clientData?.client, address]);
-
-  useEffect(() => {
     const registrationStatus = registration
       ? registration.account === account
       : false;

--- a/packages/react/src/hooks/useW3IAccount.ts
+++ b/packages/react/src/hooks/useW3IAccount.ts
@@ -41,7 +41,7 @@ export const useW3iAccount = (address?: string): W3iAccountReturn => {
       return clientData?.client.prepareRegistration({ account });
     }
 
-    throw new Error("Web3InboxClient not ready, cannot prepare");
+    throw new Error("Web3InboxClient not ready, cannot prepare registration");
   };
 
   const register = useCallback(

--- a/packages/react/src/hooks/useW3IAccount.ts
+++ b/packages/react/src/hooks/useW3IAccount.ts
@@ -24,7 +24,7 @@ type W3iAccountReturn = HooksReturn<
 >;
 
 export const useW3iAccount = (address?: string): W3iAccountReturn => {
-  const { data: web3inboxClientData } = useWeb3InboxClient();
+  const { data: web3inboxClientData, isLoading } = useWeb3InboxClient();
 
   const [isRegistered, setIsRegistered] = useState<boolean>(false);
   const [isRegistering, setIsRegistering] = useState<boolean>(false);
@@ -95,10 +95,8 @@ export const useW3iAccount = (address?: string): W3iAccountReturn => {
   if (!web3inboxClientData) {
     return {
       data: null,
-
       isLoading: true,
       error: null,
-
       prepareRegistration,
       register,
       unregister,
@@ -113,7 +111,6 @@ export const useW3iAccount = (address?: string): W3iAccountReturn => {
       isRegistering,
       identityKey: isRegistered && registration ? registration.identity : null,
     },
-
     isLoading: false,
     error: null,
     prepareRegistration,

--- a/packages/react/src/hooks/useWeb3InboxClient.ts
+++ b/packages/react/src/hooks/useWeb3InboxClient.ts
@@ -2,11 +2,7 @@ import { Web3InboxClient } from "@web3inbox/core";
 import { useEffect, useState } from "react";
 import { HooksReturn, LoadingOf, SuccessOf } from "../types/hooks";
 
-type Web3InboxClientReturn = HooksReturn<
-  { client: Web3InboxClient },
-  {},
-  "client"
->;
+type Web3InboxClientReturn = HooksReturn<Web3InboxClient, {}, "client">;
 
 export const useWeb3InboxClient = (): Web3InboxClientReturn => {
   const [isReady, setIsReady] = useState(Web3InboxClient.getIsReady());
@@ -30,9 +26,7 @@ export const useWeb3InboxClient = (): Web3InboxClientReturn => {
 
   if (isReady && client) {
     return {
-      data: {
-        client,
-      },
+      data: client,
       isLoading: false,
       error: null,
     } as SuccessOf<Web3InboxClientReturn>;

--- a/packages/react/src/utils/snapshots.ts
+++ b/packages/react/src/utils/snapshots.ts
@@ -1,9 +1,9 @@
 import { Web3InboxClient, valtio } from "@web3inbox/core";
 
 export const useSubscriptionState = () => {
-  return valtio.useSnapshot(Web3InboxClient.subscriptionState)
+  return valtio.useSnapshot(Web3InboxClient.subscriptionState);
 };
 
 export const useClientState = () => {
-  return valtio.useSnapshot(Web3InboxClient.clientState)
+  return valtio.useSnapshot(Web3InboxClient.clientState);
 };


### PR DESCRIPTION
# Description

Refactored the `useW3iAccount` hook life cycles and dependencies a bit since previously it wasn't able to set the account to the client at the first render when the client is ready. 

Updated the example app a bit to reflect the loading states to give better feedback to user.
