### PR TITLE
fix: bugs in watch subscriptions

### DIFF
--- a/apps/web/components/Subscription.tsx
+++ b/apps/web/components/Subscription.tsx
@@ -38,7 +38,11 @@ function Subscription() {
           >
             {hooksReturn.isLoading
               ? "Loading.."
-              : JSON.stringify(hooksReturn.error ?? hooksReturn.data?.subscription, undefined, 2)}
+              : JSON.stringify(
+                  hooksReturn.error ?? hooksReturn.data?.subscription,
+                  undefined,
+                  2
+                )}
           </pre>
         </Code>
       </AccordionPanel>

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -240,13 +240,7 @@ export class Web3InboxClient {
 
     Web3InboxClient.clientState.initting = false;
 
-    if (notifyClient.hasFinishedInitialLoad()) {
-      Web3InboxClient.clientState.isReady = true;
-    } else {
-      notifyClient.once("notify_subscriptions_changed", () => {
-        Web3InboxClient.clientState.isReady = true;
-      });
-    }
+    Web3InboxClient.clientState.isReady = true;
 
     return Web3InboxClient.instance;
   }

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -98,6 +98,7 @@ export class Web3InboxClient {
    */
   public static watchIsReady(cb: (isReady: boolean) => void) {
     cb(Web3InboxClient.clientState.isReady);
+
     return subscribe(Web3InboxClient.clientState, () => {
       cb(Web3InboxClient.clientState.isReady);
     });
@@ -143,6 +144,7 @@ export class Web3InboxClient {
    */
   public watchAccount(cb: (acc: string | undefined) => void) {
     cb(Web3InboxClient.clientState.account);
+
     return subscribe(Web3InboxClient.clientState, () => {
       return cb(Web3InboxClient.clientState.account);
     });
@@ -178,6 +180,7 @@ export class Web3InboxClient {
     cb: (isRegistered: boolean) => void
   ) {
     this.getAccountIsRegistered(account).then(cb);
+
     return subscribe(Web3InboxClient.clientState, async () => {
       cb(await this.getAccountIsRegistered(account));
     });
@@ -326,7 +329,6 @@ export class Web3InboxClient {
     account?: string,
     domain?: string
   ) {
-    console.log("watching subscription for, ", account);
     cb(this.getSubscription(account, domain));
 
     return subscribe(Web3InboxClient.subscriptionState, () => {
@@ -682,6 +684,7 @@ export class Web3InboxClient {
     domain?: string
   ) {
     cb(this.isSubscribedToDapp(account, domain));
+
     return subscribe(Web3InboxClient.subscriptionState, () => {
       cb(this.isSubscribedToDapp(account, domain));
     });
@@ -701,6 +704,7 @@ export class Web3InboxClient {
     domain?: string
   ) {
     cb(this.getSubscription(account, domain)?.scope ?? {});
+
     return subscribe(Web3InboxClient.subscriptionState, () => {
       cb(this.getSubscription(account, domain)?.scope ?? {});
     });

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -177,7 +177,7 @@ export class Web3InboxClient {
     account: string,
     cb: (isRegistered: boolean) => void
   ) {
-    this.getAccountIsRegistered(account).then(cb)
+    this.getAccountIsRegistered(account).then(cb);
     return subscribe(Web3InboxClient.clientState, async () => {
       cb(await this.getAccountIsRegistered(account));
     });
@@ -240,13 +240,12 @@ export class Web3InboxClient {
 
     Web3InboxClient.clientState.initting = false;
 
-    if(notifyClient.hasFinishedInitialLoad()) {
+    if (notifyClient.hasFinishedInitialLoad()) {
       Web3InboxClient.clientState.isReady = true;
-    }
-    else {
+    } else {
       notifyClient.once("notify_subscriptions_changed", () => {
         Web3InboxClient.clientState.isReady = true;
-      })
+      });
     }
 
     return Web3InboxClient.instance;
@@ -333,8 +332,8 @@ export class Web3InboxClient {
     account?: string,
     domain?: string
   ) {
-    console.log("watching subscription for, ", account)
-    cb(this.getSubscription(account, domain))
+    console.log("watching subscription for, ", account);
+    cb(this.getSubscription(account, domain));
 
     return subscribe(Web3InboxClient.subscriptionState, () => {
       cb(this.getSubscription(account, domain));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,3 @@
 export { Web3InboxClient } from "./client";
 
-export * as valtio from "valtio"
+export * as valtio from "valtio";

--- a/packages/core/test/client.spec.ts
+++ b/packages/core/test/client.spec.ts
@@ -140,7 +140,7 @@ describe("Web3Inbox Core Client", () => {
       expect(subs).toEqual([]);
     });
 
-    it("correctly updates ready state", async () => {
+    it.skipIf(!projectId)("correctly updates ready state", async () => {
       expect(Web3InboxClient.clientState.isReady).toEqual(false);
 
       // Not awaiting to be able to observe initting state.
@@ -150,7 +150,6 @@ describe("Web3Inbox Core Client", () => {
 
       await waitForEvent(() => {
         return (
-          !Web3InboxClient.clientState.initting &&
           Web3InboxClient.clientState.isReady
         );
       });

--- a/packages/core/test/client.spec.ts
+++ b/packages/core/test/client.spec.ts
@@ -51,7 +51,6 @@ const testSub3 = {
 };
 
 const resetSingletonState = () => {
-  Web3InboxClient.view = proxy({ isOpen: false });
   Web3InboxClient.subscriptionState = proxy({
     subscriptions: [],
     messages: [],
@@ -89,7 +88,7 @@ const initNonSingletonInstanceW3i = async (
 
   const notifyClient = await NotifyClient.init(notifyParams);
 
-  const w3iClient = new Web3InboxClient(notifyClient, withDomain);
+  const w3iClient = new Web3InboxClient(notifyClient, withDomain, true);
 
   Web3InboxClient.instance = w3iClient;
 
@@ -150,7 +149,7 @@ describe("Web3Inbox Core Client", () => {
       expect(Web3InboxClient.clientState.initting).toEqual(true);
 
       await waitForEvent(() => {
-        return !Web3InboxClient.clientState.initting;
+        return !Web3InboxClient.clientState.initting && Web3InboxClient.clientState.isReady;
       });
 
       expect(Web3InboxClient.clientState.isReady).toEqual(true);

--- a/packages/core/test/client.spec.ts
+++ b/packages/core/test/client.spec.ts
@@ -149,7 +149,10 @@ describe("Web3Inbox Core Client", () => {
       expect(Web3InboxClient.clientState.initting).toEqual(true);
 
       await waitForEvent(() => {
-        return !Web3InboxClient.clientState.initting && Web3InboxClient.clientState.isReady;
+        return (
+          !Web3InboxClient.clientState.initting &&
+          Web3InboxClient.clientState.isReady
+        );
       });
 
       expect(Web3InboxClient.clientState.isReady).toEqual(true);

--- a/packages/react/src/hooks/useManageSubscription.ts
+++ b/packages/react/src/hooks/useManageSubscription.ts
@@ -44,13 +44,9 @@ export const useManageSubscription = (
 
   useEffect(() => {
     if (w3iClient) {
-      console.log(
-        ">>>>1 stting sub",
-        w3iClient.getSubscription(account, domain)
-      );
       setSubscription(w3iClient.getSubscription(account, domain));
     }
-  }, [clientLoading, w3iClient]);
+  }, [w3iClient]);
 
   useEffect(() => {
     console.log({ w3iClient });
@@ -151,8 +147,6 @@ export const useManageSubscription = (
     subscription,
     isSubscribed: Boolean(subscription),
   };
-
-  console.log(">>>>1 data: ", data);
 
   return {
     data,

--- a/packages/react/src/hooks/useManageSubscription.ts
+++ b/packages/react/src/hooks/useManageSubscription.ts
@@ -26,7 +26,7 @@ export const useManageSubscription = (
   account?: string,
   domain?: string
 ): ManageSubscriptionReturn => {
-  const { data: w3iClient, error: clientError } = useWeb3InboxClient();
+  const { data: w3iClient, isLoading: clientLoading, error: clientError } = useWeb3InboxClient();
 
   const [subscription, setSubscription] =
     useState<NotifyClientTypes.NotifySubscription | null>(
@@ -39,6 +39,14 @@ export const useManageSubscription = (
   const [isUnsubscribing, setIsUnsubscribing] = useState(false);
 
   useEffect(() => {
+    if(w3iClient) {
+      console.log(">>>>1 stting sub", w3iClient.getSubscription(account, domain) )
+      setSubscription(w3iClient.getSubscription(account, domain))
+    }
+  }, [clientLoading, w3iClient])
+
+  useEffect(() => {
+    console.log({w3iClient})
     if (!w3iClient || watching) return;
 
     const stopWatching = w3iClient.watchSubscription(
@@ -56,7 +64,7 @@ export const useManageSubscription = (
       setWatching(false);
       stopWatching();
     };
-  }, [account, domain]);
+  }, [account, domain, w3iClient]);
 
   const subscribe = async () => {
     if (!w3iClient) {
@@ -130,13 +138,17 @@ export const useManageSubscription = (
     } as ErrorOf<ManageSubscriptionReturn>;
   }
 
-  return {
-    data: {
+  const data = {
       isSubscribing,
       isUnsubscribing,
       subscription,
       isSubscribed: Boolean(subscription),
-    },
+    }
+
+  console.log(">>>>1 data: ", data)
+
+  return {
+    data,
     isLoading: false,
     error: null,
     unsubscribe,

--- a/packages/react/src/hooks/useManageSubscription.ts
+++ b/packages/react/src/hooks/useManageSubscription.ts
@@ -43,10 +43,10 @@ export const useManageSubscription = (
   const [isUnsubscribing, setIsUnsubscribing] = useState(false);
 
   useEffect(() => {
-    if (w3iClient) {
+    if (w3iClient && !clientLoading) {
       setSubscription(w3iClient.getSubscription(account, domain));
     }
-  }, [w3iClient]);
+  }, [w3iClient, clientLoading]);
 
   useEffect(() => {
     console.log({ w3iClient });

--- a/packages/react/src/hooks/useManageSubscription.ts
+++ b/packages/react/src/hooks/useManageSubscription.ts
@@ -26,7 +26,11 @@ export const useManageSubscription = (
   account?: string,
   domain?: string
 ): ManageSubscriptionReturn => {
-  const { data: w3iClient, isLoading: clientLoading, error: clientError } = useWeb3InboxClient();
+  const {
+    data: w3iClient,
+    isLoading: clientLoading,
+    error: clientError,
+  } = useWeb3InboxClient();
 
   const [subscription, setSubscription] =
     useState<NotifyClientTypes.NotifySubscription | null>(
@@ -39,14 +43,17 @@ export const useManageSubscription = (
   const [isUnsubscribing, setIsUnsubscribing] = useState(false);
 
   useEffect(() => {
-    if(w3iClient) {
-      console.log(">>>>1 stting sub", w3iClient.getSubscription(account, domain) )
-      setSubscription(w3iClient.getSubscription(account, domain))
+    if (w3iClient) {
+      console.log(
+        ">>>>1 stting sub",
+        w3iClient.getSubscription(account, domain)
+      );
+      setSubscription(w3iClient.getSubscription(account, domain));
     }
-  }, [clientLoading, w3iClient])
+  }, [clientLoading, w3iClient]);
 
   useEffect(() => {
-    console.log({w3iClient})
+    console.log({ w3iClient });
     if (!w3iClient || watching) return;
 
     const stopWatching = w3iClient.watchSubscription(
@@ -139,13 +146,13 @@ export const useManageSubscription = (
   }
 
   const data = {
-      isSubscribing,
-      isUnsubscribing,
-      subscription,
-      isSubscribed: Boolean(subscription),
-    }
+    isSubscribing,
+    isUnsubscribing,
+    subscription,
+    isSubscribed: Boolean(subscription),
+  };
 
-  console.log(">>>>1 data: ", data)
+  console.log(">>>>1 data: ", data);
 
   return {
     data,


### PR DESCRIPTION
- fix bug where subscription state doesnt update
- pulse state in `watch` functions when initially called
- add `w3iClient` in dependency hook
- run prettier
- change init logic to account for notify client init call