### PR TITLE
chore: export different types of js files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,11 +1,20 @@
 {
   "name": "@web3inbox/core",
   "version": "0.0.25",
+  "type": "module",
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsup ",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,8 +2,8 @@
   "name": "@web3inbox/core",
   "version": "0.0.25",
   "type": "module",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -11,9 +11,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    }
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
   },
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,8 +2,8 @@
   "name": "@web3inbox/widget-react",
   "version": "0.6.26",
   "type": "module",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -11,9 +11,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    }
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
   },
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,11 +1,20 @@
 {
   "name": "@web3inbox/widget-react",
   "version": "0.6.26",
+  "type": "module",
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
- change `type` to `module`
- include `mjs` files in `export`, as well as include the `js` (commonjs) files for compatibility
- include `types` in the exports
- Based on [Viem's setup](https://github.com/wevm/viem/blob/main/src/package.json)
- Resolves #61 
